### PR TITLE
Fix case report merging bug.

### DIFF
--- a/meerkat_abacus/country_config/locations/demo_clinics.csv
+++ b/meerkat_abacus/country_config/locations/demo_clinics.csv
@@ -1,5 +1,5 @@
 "who_code","deviceid","sim_id","clinic","country_location_id","clinic_type","case_report","case_type","device_tags","district","region","longitude","latitude","start_date","population"
-1,1,1,"Clinic 1","unique_code_1","Primary","Yes","mh","CD","District 1","Region 1",0.1,0.1,"01/02/16",10000
+1,1,1,"Clinic 1","unique_code_1","Primary","No","mh","CD","District 1","Region 1",0.1,0.1,"01/02/16",10000
 2,2,2,"Clinic 2","unique_code_2","Primary","Yes","pip","CD","District 1","Region 1",0.2,0.2,"01/02/16",5000
 3,3,3,"Clinic 3","unique_code_3","Focal","No",,"CD,NCD","District 1","Region 1",0.3,0.2,"01/02/16",4000
 4,4,4,"Clinic 4","unique_code_4","Primary","Yes","mh, pip, foreigner","CD,NCD","District 2","Region 1",0.2,0.3,"01/02/16",10000

--- a/meerkat_abacus/data_management.py
+++ b/meerkat_abacus/data_management.py
@@ -279,8 +279,9 @@ def import_clinics(csv_file, session, country_id,
     with open(csv_file) as f:
         clinics_csv = csv.DictReader(f)
         for row in clinics_csv:
-            if row["deviceid"] and row["clinic"].lower() != "not used" and row[
-                "deviceid"] not in deviceids:
+            if (row["deviceid"] and
+               row["clinic"].lower() != "not used" and
+               row["deviceid"] not in deviceids):
 
                 other_cond = True
                 if other_condition:
@@ -290,6 +291,7 @@ def import_clinics(csv_file, session, country_id,
                             break
                 if not other_cond:
                     continue
+
                 if "case_report" in row.keys():
                     if row["case_report"] in ["Yes", "yes"]:
                         case_report = 1
@@ -382,9 +384,13 @@ def import_clinics(csv_file, session, country_id,
                 else:
                     location = result.first()
                     location.deviceid += "," + row["deviceid"]
+                     # Combine case types with no duplicates
                     location.case_type = list(
                         set(location.case_type) | set(case_type)
-                    )  # Combine case types with no duplicates
+                    )
+                    # Clinic submits cases if any of it's tablets submits cases
+                    if row["case_report"] or location.case_report:
+                        location.case_report = 1
     session.commit()
 
 

--- a/meerkat_abacus/test/db_test.py
+++ b/meerkat_abacus/test/db_test.py
@@ -70,8 +70,10 @@ class DbTest(unittest.TestCase):
             if r.name == "Clinic 1":
                 if r.parent_location == 6:
                     self.assertEqual(r.deviceid, "1,6")
+                    self.assertTrue(r.case_report)
                 else:
                     self.assertEqual(r.deviceid, "7")
+
             if r.name == "Clinic 2":
                 self.assertEqual(r.start_date, datetime(2016, 2, 2))
             elif r.level == "clinic":

--- a/meerkat_abacus/test/test_data/locations/demo_clinics.csv
+++ b/meerkat_abacus/test/test_data/locations/demo_clinics.csv
@@ -1,8 +1,8 @@
-who_code,deviceid,sim_id,clinic,clinic_type,case_report,district,region,longitude,latitude,start_date,
-1,1,1,Clinic 1,Primary,Yes,District 1,Region 1,0.1,0.1,,
-2,2,2,Clinic 2,Primary,Yes,District 1,Region 1,0.2,0.2,"02/02/2016",
-3,3,3,Clinic 3,Focal,No,District 1,Region 1,0.3,0.2,,
-4,4,4,Clinic 4,Primary,Yes,District 2,Region 1,0.2,0.3,,
-5,5,5,Clinic 5,Hospital,Yes,,Region 2,0.4,-0.1,,
-6,6,6,Clinic 1,Primary,Yes,District 1,Region 1,0.1,0.1,,
-7,7,7,Clinic 1,Primary,Yes,District 2,Region 1,0.1,0.1,,
+"who_code","deviceid","sim_id","clinic","clinic_type","case_report","district","region","longitude","latitude","start_date"
+1,1,1,"Clinic 1","Primary","No","District 1","Region 1",0.1,0.1,
+2,2,2,"Clinic 2","Primary","Yes","District 1","Region 1",0.2,0.2,"02/02/2016"
+3,3,3,"Clinic 3","Focal","No","District 1","Region 1",0.3,0.2,
+4,4,4,"Clinic 4","Primary","Yes","District 2","Region 1",0.2,0.3,
+5,5,5,"Clinic 5","Hospital","Yes",,"Region 2",0.4,-0.1,
+6,6,6,"Clinic 1","Primary","Yes","District 1","Region 1",0.1,0.1,
+7,7,7,"Clinic 1","Primary","Yes","District 2","Region 1",0.1,0.1,


### PR DESCRIPTION
If any tablet in a clinic is submitting case reports, then that clinic as a whole should be considered to be submitting case reports. 

Previously we have taken the value of `case_report` from the first tablet associated with a clinic in the tablet inventory. If any later tablets at the same clinic had different value, there was no overriding.  

This pull request therefore introuces OR logic to the merging of "case_report" from many tablets to one clinic. If ANY of the tablets have `case_report` set to true, then the clinic's `case_report` field is set to true.

Test is included.
